### PR TITLE
Support for all Rollbar options

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Installation
         // ...
         'rollbar' => array(
             'class' => 'application.vendor.baibaratsky.yii-rollbar.RollbarComponent', // adjust path if needed
-            'accessToken' => 'your_serverside_rollbar_token',
+            'access_token' => 'your_serverside_rollbar_token',
         ),
     ),
     ```
@@ -55,8 +55,9 @@ Installation
     ),
     ```
 
-    You can also pass some additional rollbar options in the component config:
-    `environment`, `branch`, `maxErrno`, `baseApiUrl`, etc.
+    You can also pass some additional rollbar options in the component config, refer to the 
+    [Rollbar documentation](https://rollbar.com/docs/notifier/rollbar-php/#configuration-reference)
+    for all available options.
 
     A good idea is to specify `environment` as:
 
@@ -66,7 +67,7 @@ Installation
 
     You can specify alias of your project root directory for linking stack traces (`application` by default):
     ```php
-    'rootAlias' => 'root',
+    'root' => 'root',
     ```
 
 

--- a/RollbarComponent.php
+++ b/RollbarComponent.php
@@ -14,10 +14,13 @@ class RollbarComponent extends CApplicationComponent
         Rollbar::init($this->config, false, false);
         parent::init();
     }
-    
-    public function __set($key, $value) {
-      if ( $key === 'root' ) {
-        $value = YiiBase::getPathOfAlias( $value ) ? YiiBase::getPathOfAlias( $value ) : $value;
+
+    public function __set($key, $value)
+    {
+      $key = $this->normalizeWithCompatibility($key);
+      
+      if ($key === 'root') {
+          $value = Yii::getPathOfAlias( $value ) ? Yii::getPathOfAlias( $value ) : $value;
       }
       $this->config[$key] = $value;
     }
@@ -26,5 +29,30 @@ class RollbarComponent extends CApplicationComponent
     {
         $this->root = Yii::getPathOfAlias('application');
         $this->scrub_fields = ['passwd', 'password', 'secret', 'auth_token', 'YII_CSRF_TOKEN'];
+    }
+
+    /**
+     * Converts old public properties to new key names.
+     */
+    protected function normalizeWithCompatibility($key)
+    {
+        if ($key === 'rootAlias') {
+            $key = 'root';
+        }
+        $key = $this->underscore($key);
+    }
+
+    /**
+     * Converts any "CamelCased" into an "underscored_word".
+     *
+     * Taken from 
+     * https://github.com/yiisoft/yii2/blob/6da1ec6fb2b6367cb30d8c581575d09f0072812d/framework/helpers/BaseInflector.php#L411
+     * 
+     * @param string $words the word(s) to underscore
+     * @return string
+     */
+    private function underscore($words)
+    {
+        return strtolower(preg_replace('/(?<=\\w)([A-Z])/', '_\\1', $words));
     }
 }

--- a/RollbarComponent.php
+++ b/RollbarComponent.php
@@ -2,41 +2,29 @@
 
 class RollbarComponent extends CApplicationComponent
 {
-    public $accessToken;
-    public $environment;
-    public $branch;
-    public $code_version;
-    public $host;
-    public $batched;
-    public $batchSize;
-    public $timeout;
-    public $logger;
-    public $includedErrno;
-    public $baseApiUrl;
-    public $rootAlias = 'application';
-    public $scrubFields = ['passwd', 'password', 'secret', 'auth_token', 'YII_CSRF_TOKEN'];
+    private $config = [];
+
+    public function __construct()
+    {
+        $this->setDefaults();
+    }
 
     public function init()
     {
-        Rollbar::init(
-            array(
-                'access_token' => $this->accessToken,
-                'environment' => $this->environment,
-                'branch' => $this->branch,
-                'code_version' => $this->code_version,
-                'host' => $this->host,
-                'batched' => $this->batched,
-                'batch_size' => $this->batchSize,
-                'timeout' => $this->timeout,
-                'logger' => $this->logger,
-                'included_errno' => $this->includedErrno,
-                'base_api_url' => $this->baseApiUrl,
-                'root' => !empty($this->rootAlias) ? Yii::getPathOfAlias($this->rootAlias) : '',
-                'scrub_fields' => $this->scrubFields,
-            ),
-            false,
-            false);
-
+        Rollbar::init($this->config, false, false);
         parent::init();
+    }
+    
+    public function __set($key, $value) {
+      if ( $key === 'root' ) {
+        $value = YiiBase::getPathOfAlias( $value ) ? YiiBase::getPathOfAlias( $value ) : $value;
+      }
+      $this->config[$key] = $value;
+    }
+
+    protected function setDefaults()
+    {
+        $this->root = Yii::getPathOfAlias('application');
+        $this->scrub_fields = ['passwd', 'password', 'secret', 'auth_token', 'YII_CSRF_TOKEN'];
     }
 }


### PR DESCRIPTION
Hello, I was in need of setting more Rollbar configurations than the one included in this component, and I though to rewrite the logic to permit setting all Rollbar options ( future ones too ).

I also rewrote it to use [Rollbar documented options](https://rollbar.com/docs/notifier/rollbar-php/#configuration-reference) ( snake_case instead of CamelCase ), in order to minimize documentation for this components ( as you can refer to available Rollbar documentation ).

As I didn't want to break compatibility with current version configuration, I made the edit backward compatible.

Thank you for your work in maintaining this project!
